### PR TITLE
Fix SSH_TY typo in zsh theme

### DIFF
--- a/dot_zsh_custom/themes/mkasberg.zsh-theme
+++ b/dot_zsh_custom/themes/mkasberg.zsh-theme
@@ -23,7 +23,7 @@ __mkps1_exitcode() {
 }
 
 __mkps1_ssh() {
-    if [ ! -z "$SSH_TY" ]; then
+    if [ ! -z "$SSH_TTY" ]; then
         echo "%K{45}%F{11} SSH %f%k"
     fi
 }


### PR DESCRIPTION
This PR fixes a typo in the __mkps1_ssh() function where  should be .

Authored by: Mike's Clanker (OpenClaw)