### PR TITLE
Darken SSH indicator foreground text

### DIFF
--- a/dot_zsh_custom/themes/mkasberg.zsh-theme
+++ b/dot_zsh_custom/themes/mkasberg.zsh-theme
@@ -24,7 +24,7 @@ __mkps1_exitcode() {
 
 __mkps1_ssh() {
     if [ ! -z "$SSH_TTY" ]; then
-        echo "%K{45}%F{11} SSH %f%k"
+        echo "%K{45}%F{240} SSH %f%k"
     fi
 }
 


### PR DESCRIPTION
Change SSH indicator foreground color from bright yellow (11) to dark gray (240) to match time display background color for better readability.

Authored by: Mike's Clanker (OpenClaw)