### PR TITLE
Add guarded OpenClaw completions to bashrc and zshrc

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -146,6 +146,11 @@ if command -v mise >/dev/null; then
     eval "$(mise activate bash)"
 fi
 
+# OpenClaw Completions
+if command -v openclaw &> /dev/null; then
+    source <(openclaw completion --shell bash)
+fi
+
 # Add Go
 if [ -d "/usr/local/go/bin" ]; then
     PATH="/usr/local/go/bin:$PATH"
@@ -154,7 +159,7 @@ fi
 # NPM/Yarn User-installed Packages
 export PATH="$PATH:$HOME/.npm-packages/bin"
 
-# Bloop Complpetion
+# Bloop Completion
 if [ -e "$HOME/.bloop/bash/bloop" ]; then
     . $HOME/.bloop/bash/bloop
 fi

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -159,6 +159,11 @@ if [ -d "/home/linuxbrew/.linuxbrew/bin" ]; then
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
 
+# OpenClaw Completions (if installed)
+if command -v openclaw &> /dev/null; then
+    source <(openclaw completion --shell zsh)
+fi
+
 # Uncomment to print startup profiling.
 # Don't forget to also uncomment the line to begin profiling near the top.
 # zprof


### PR DESCRIPTION
Add conditional OpenClaw command completion sourcing to both .bashrc and .zshrc with proper guard checks to prevent errors on machines without OpenClaw installed.

Also fix 'Complpetion' typo in Bloop section comment.

Authored by: Mike's Clanker (OpenClaw)